### PR TITLE
feat: default chain identifier and make imports easier

### DIFF
--- a/offchain/__init__.py
+++ b/offchain/__init__.py
@@ -1,0 +1,1 @@
+from . import metadata

--- a/offchain/metadata/__init__.py
+++ b/offchain/metadata/__init__.py
@@ -1,1 +1,1 @@
-from . import adapters, fetchers, parsers
+from . import adapters, fetchers, models, parsers

--- a/offchain/metadata/adapters/__init__.py
+++ b/offchain/metadata/adapters/__init__.py
@@ -1,14 +1,5 @@
-from offchain.base.types import StringEnum
-
 from .arweave import ARWeaveAdapter
 from .base_adapter import BaseAdapter
 from .data_uri import DataURIAdapter
 from .http_adapter import HTTPAdapter
 from .ipfs import IPFSAdapter
-
-
-class AdapterType(StringEnum):
-    ARWeaveAdapter = ARWeaveAdapter.__name__
-    DataURIAdapter = DataURIAdapter.__name__
-    HTTPAdapter = HTTPAdapter.__name__
-    IPFSAdapter = IPFSAdapter.__name__

--- a/offchain/metadata/fetchers/__init__.py
+++ b/offchain/metadata/fetchers/__init__.py
@@ -1,8 +1,2 @@
-from offchain.base.types import StringEnum
-
 from .base_fetcher import BaseFetcher
 from .metadata_fetcher import MetadataFetcher
-
-
-class FetcherType(StringEnum):
-    MetadataFetcher = MetadataFetcher.__name__

--- a/offchain/metadata/models/__init__.py
+++ b/offchain/metadata/models/__init__.py
@@ -1,0 +1,10 @@
+from .token import Token
+from .metadata import (
+    Attribute,
+    MediaDetails,
+    Metadata,
+    MetadataField,
+    MetadataFieldType,
+    MetadataStandard,
+)
+from .metadata_processing_error import MetadataProcessingError

--- a/offchain/metadata/models/metadata_processing_error.py
+++ b/offchain/metadata/models/metadata_processing_error.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from offchain.base.base_model import BaseModel
 from offchain.metadata.models.token import Token
 
@@ -8,19 +6,12 @@ class MetadataProcessingError(BaseModel):
     """Interface for metadata processing errors and relevant contextual information.
 
     Attributes:
-        chain_identifier (str): identifier for network and chain of token,
-            formatted as NETWORK_NAME-CHAIN_NAME (e.g. "ETHEREUM-MAINNET").
-        collection_address (str): collection address of the token.
-        token_id (int): token id of the token.
-        uri (str): metadata uri of the token.
+        token (Token): a Token interface with all information required to uniquely identify an NFT
         error_type (str): the class of caught exception.
         error_message (str): the error message of the caught exception.
     """
 
-    chain_identifier: str
-    collection_address: str
-    token_id: int
-    uri: Optional[str]
+    token = Token
 
     error_type: str
     error_message: str
@@ -28,10 +19,7 @@ class MetadataProcessingError(BaseModel):
     @staticmethod
     def from_token_and_error(token: Token, e: Exception) -> "MetadataProcessingError":
         return MetadataProcessingError(
-            chain_identifier=token.chain_identifier,
-            collection_address=token.collection_address,
-            token_id=token.token_id,
-            uri=token.uri,
+            token=token,
             error_type=e.__class__.__name__,
             error_message=str(e),
         )

--- a/offchain/metadata/models/token.py
+++ b/offchain/metadata/models/token.py
@@ -14,7 +14,7 @@ class Token(BaseModel):
         uri (str, optional): the uri where the metadata is stored.
     """
 
-    chain_identifier: str
     collection_address: str
     token_id: int
+    chain_identifier: str = "ETHEREUM-MAINNET"
     uri: Optional[str] = None


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- default chain identifier to `"ETHEREUM-MAINNET"`
- scope hoist for easier imports, e.g. `from offchain import IPFSAdapter`
- BREAKING CHANGE: use `Token` interface in `MetadataProcessingError`

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
