### PR TITLE
added missing changelog for bumping web3 dep

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.5
+
+- bump web3 dependency to latest version
+
 ## v0.1.4
 
 - bug fix: parse mime type for Manifold NFT metadata


### PR DESCRIPTION
Im not sure the workflow for bumping versions....but [in this PR](https://github.com/ourzora/offchain/pull/77) which was merged, I bumped the version; now I realize the version is missing from the changelog, so I added it here.