### PR TITLE
Truncate token uri in logging

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.3.1
+
+- Trim token_uri in some log outputs, this is mainly useful for data uris that are too long and make logs unreadable
+- Fix `FoundationParser`, the API it relied on doesn't exist anymore, so we are falling back to contract calls to get the metadata
+
 ## v0.3.0
 
 - Upgrade web3 to 6.11.3

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-Documentation for version: **v0.3.0**
+Documentation for version: **v0.3.1**
 
 ## Overview
 

--- a/offchain/metadata/pipelines/metadata_pipeline.py
+++ b/offchain/metadata/pipelines/metadata_pipeline.py
@@ -25,6 +25,15 @@ DEFAULT_PARSERS = (
 )
 
 
+def _truncate_uri(uri: str, max_length: int = 100) -> str:
+    if len(uri) <= max_length:
+        return uri
+
+    keep_length = (max_length - 3) // 2  # 3 is for the '...'
+
+    return uri[:keep_length] + "..." + uri[-keep_length:]
+
+
 class MetadataPipeline(BasePipeline):
     """Pipeline for processing NFT metadata.
 
@@ -161,7 +170,7 @@ class MetadataPipeline(BasePipeline):
             try:
                 raw_data = self.fetcher.fetch_content(token.uri)
             except Exception as e:
-                error_message = f"({token.chain_identifier}-{token.collection_address}-{token.token_id}) Failed to parse token uri: {token.uri}. {str(e)}"  # noqa: E501
+                error_message = f"({token.chain_identifier}-{token.collection_address}-{token.token_id}) Failed to parse token uri: {_truncate_uri(token.uri)}. {str(e)}"  # noqa: E501
                 logger.error(error_message)
                 possible_metadatas_or_errors.append(
                     MetadataProcessingError.from_token_and_error(
@@ -216,9 +225,9 @@ class MetadataPipeline(BasePipeline):
             Union[Metadata, MetadataProcessingError]: returns either a Metadata
                 or a MetadataProcessingError if unable to parse.
         """
-        possible_metadatas_or_errors: list[
-            Union[Metadata, MetadataProcessingError]
-        ] = []
+        possible_metadatas_or_errors: list[Union[Metadata, MetadataProcessingError]] = (
+            []
+        )
 
         if not token.uri:
             return MetadataProcessingError.from_token_and_error(
@@ -230,7 +239,7 @@ class MetadataPipeline(BasePipeline):
         try:
             raw_data = await self.fetcher.gen_fetch_content(token.uri)
         except Exception as e:
-            error_message = f"({token.chain_identifier}-{token.collection_address}-{token.token_id}) Failed to parse token uri: {token.uri}. {str(e)}"  # noqa: E501
+            error_message = f"({token.chain_identifier}-{token.collection_address}-{token.token_id}) Failed to parse token uri: {_truncate_uri(token.uri)}. {str(e)}"  # noqa: E501
             logger.error(error_message)
             possible_metadatas_or_errors.append(
                 MetadataProcessingError.from_token_and_error(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "offchain"
-version = "0.3.0"
+version = "0.3.1"
 description = "Open source metadata processing framework"
 authors = ["Zora eng <eng@zora.co>"]
 readme = "README.md"

--- a/tests/metadata/fetchers/test_metadata_fetcher.py
+++ b/tests/metadata/fetchers/test_metadata_fetcher.py
@@ -54,7 +54,7 @@ class TestMetadataFetcher:
     async def test_gen_fetch_mime_type_and_size(self):  # type: ignore[no-untyped-def]
         fetcher = MetadataFetcher()
         result = await fetcher.gen_fetch_mime_type_and_size(
-            "https://ipfs.io/ipfs/QmQaYaf3Q2oCBaUfUvV6mBP58EjbUTbMk6dC1o4YGjeWCo"
+            "https://ipfs.decentralized-content.com/ipfs/QmQaYaf3Q2oCBaUfUvV6mBP58EjbUTbMk6dC1o4YGjeWCo"
         )
         assert result == ("image/png", "2887641")  # type: ignore[comparison-overlap]
         print(result)

--- a/tests/metadata/parsers/test_foundation_parser.py
+++ b/tests/metadata/parsers/test_foundation_parser.py
@@ -22,9 +22,7 @@ class TestFoundationParser:
     raw_data = {
         "name": "Experiment #0004",
         "description": "They rise again!",
-        "image": "https://d1hiserqh6k9o1.cloudfront.net/Ax/kk/QmWwB2LXk7VKu5KtDrtUYdwpHK1NvJ49XrQvFRJxqiAxkk/nft.png",
-        "animation_url": "ipfs://QmWwB2LXk7VKu5KtDrtUYdwpHK1NvJ49XrQvFRJxqiAxkk/nft.glb",
-        "external_url": "https://foundation.app/@pw_3Dlab/foundation/113384",
+        "image": "ipfs://QmWwB2LXk7VKu5KtDrtUYdwpHK1NvJ49XrQvFRJxqiAxkk/nft.glb",
     }
 
     def test_foundation_parser_should_parse_token(self):  # type: ignore[no-untyped-def]
@@ -37,7 +35,7 @@ class TestFoundationParser:
         fetcher = MetadataFetcher()
         contract_caller = ContractCaller()
         fetcher.fetch_mime_type_and_size = MagicMock(return_value=("application/json", 0))  # type: ignore[assignment]
-        fetcher.fetch_content = MagicMock(return_value=self.raw_data)  # type: ignore[assignment]
+        fetcher.fetch_content = MagicMock(return_value=None)  # type: ignore[assignment]
         parser = FoundationParser(fetcher=fetcher, contract_caller=contract_caller)  # type: ignore[abstract]
         metadata = parser.parse_metadata(token=self.token, raw_data=self.raw_data)
         assert metadata == Metadata(
@@ -45,14 +43,12 @@ class TestFoundationParser:
                 chain_identifier="ETHEREUM-MAINNET",
                 collection_address="0x3b3ee1931dc30c1957379fac9aba94d1c48a5405",
                 token_id=113384,
-                uri="https://api.foundation.app/opensea/113384",
+                uri="ipfs://QmRxAiR7FsT78mLcyMiE1p86a77gBQVJGWfGRADtMwqyEe/metadata.json",
             ),
             raw_data={
                 "name": "Experiment #0004",
                 "description": "They rise again!",
-                "image": "https://d1hiserqh6k9o1.cloudfront.net/Ax/kk/QmWwB2LXk7VKu5KtDrtUYdwpHK1NvJ49XrQvFRJxqiAxkk/nft.png",
-                "animation_url": "ipfs://QmWwB2LXk7VKu5KtDrtUYdwpHK1NvJ49XrQvFRJxqiAxkk/nft.glb",
-                "external_url": "https://foundation.app/@pw_3Dlab/foundation/113384",
+                "image": "ipfs://QmWwB2LXk7VKu5KtDrtUYdwpHK1NvJ49XrQvFRJxqiAxkk/nft.glb",
             },
             attributes=[],
             standard=None,
@@ -62,15 +58,10 @@ class TestFoundationParser:
             image=MediaDetails(
                 size=0,
                 sha256=None,
-                uri="https://d1hiserqh6k9o1.cloudfront.net/Ax/kk/QmWwB2LXk7VKu5KtDrtUYdwpHK1NvJ49XrQvFRJxqiAxkk/nft.png",
-                mime_type="application/json",
-            ),
-            content=MediaDetails(
-                size=0,
-                sha256=None,
                 uri="ipfs://QmWwB2LXk7VKu5KtDrtUYdwpHK1NvJ49XrQvFRJxqiAxkk/nft.glb",
                 mime_type="model/gltf-binary",
             ),
+            content=None,
             additional_fields=[],
         )
 


### PR DESCRIPTION
Some URLs are very long (e.g. data urls), so we truncate them to make them easier to read in logs and use less space.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
