### PR TITLE
Added test coverage for batched_parmap

### DIFF
--- a/offchain/concurrency.py
+++ b/offchain/concurrency.py
@@ -1,8 +1,11 @@
 import multiprocessing
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Callable, Sequence
+from typing import Any, Callable, Sequence, TypeVar
 
 from offchain.logger.logging import logger
+
+T = TypeVar("T")
+U = TypeVar("U")
 
 MAX_PROCS = (multiprocessing.cpu_count() * 2) + 1
 
@@ -22,7 +25,7 @@ def parallelize_with_threads(*args: Sequence[Callable]) -> Sequence[Any]:  # typ
     return res
 
 
-def parmap(fn: Callable, args: list) -> list:  # type: ignore[type-arg]
+def parmap(fn: Callable, args: list) -> list:
     """Run a map in parallel safely
 
     Args:
@@ -39,15 +42,11 @@ def parmap(fn: Callable, args: list) -> list:  # type: ignore[type-arg]
     return list(parallelize_with_threads(*map(lambda i: lambda: fn(i), args)))  # type: ignore[arg-type]  # noqa: E501
 
 
-def batched_parmap(fn: Callable, args: list, batch_size: int = 10) -> list:  # type: ignore[type-arg]  # noqa: E501
+def batched_parmap(fn: Callable[[T], U], args: list[T], batch_size: int = 10) -> list:  # noqa: E501
     results = []
-    i, j = 0, 0
-    while i < len(args):
-        i, j = i + batch_size, i
-        if len(args) > i:
-            batch = args[j:i]
-        else:
-            batch = args[j:]
+    for i in range(0, len(args), batch_size):
+        batch_end = i + batch_size
+        batch = args[i:batch_end]
         res = parmap(fn, batch)
-        results += res
+        results.extend(res)
     return results

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,0 +1,14 @@
+import pytest
+
+from offchain.concurrency import batched_parmap
+
+
+@pytest.mark.parametrize("batch_size", range(1, 11))
+def test_batched_parmap(batch_size):
+    def square(x):
+        return x * x
+
+    args = list(range(0, 10))
+    expected = [square(x) for x in args]
+    result = batched_parmap(square, args, batch_size=batch_size)
+    assert result == expected


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added test coverage for batched_parmap function and improved its readability by simplifying the implementation. Also improved the performance by utilizing list.extend method instead of `+` concatenation. Extension modifies a list in place, instead of creating a new list by `+`

## Motivation and Context

Currently batched_parmap has unnecessary cyclomatic complexity, because it has to check for trailing chunks of batches in case when size of `args` is not divisible by `batch_size`. Even though the check is implemented, this case is not covered by tests.
Also, memory consumption of this function can be reduced by replacing list concatenation with list extension.


Fixes #104 

## How has this been tested?

I provided a unit test and ran all other tests.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
